### PR TITLE
Remove yarn --frozen-lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vega-transforms": "^4.9.0"
   },
   "scripts": {
-    "build": "yarn --frozen-lockfile && yarn workspace vega-db build",
+    "build": "yarn workspace vega-db build",
     "build:app": "yarn workspace vega-db-demo build",
     "build:server": "yarn workspace vega-db-server build",
     "cleanup": "rm -rf .cache dist node_modules && rm -rf ./packages/vega-db/node_modules ./packages/vega-db/dist ./packages/vega-db/.cache && rm -rf ./packages/demo/node_modules ./packages/demo/dist ./packages/demo/.cache && rm -rf ./packages/server/node_modules ./packages/server/dist ./packages/server/.cache",


### PR DESCRIPTION
We should not run it in the scripts.

Fixes https://github.com/leibatt/scalable-vega/issues/47